### PR TITLE
Change default branch name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,5 @@ jobs:
           cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/gatsby:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/gatsby:buildcache,mode=max
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/gatsby:test
-      - uses: actions/checkout@v4
-      - run: docker-compose -f docker-compose.test.yml run --rm sut
+      - uses: actions/checkout@v6
+      - run: docker compose run --rm gatsby

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - **Where to file issues**: [https://github.com/yukihiko-shinoda/dockerfile-gatsby/issues](https://github.com/yukihiko-shinoda/dockerfile-gatsby/issues)
 
-- **Image updates**: [Dockerfile](https://github.com/yukihiko-shinoda/dockerfile-gatsby/blob/master/Dockerfile)
+- **Image updates**: [Dockerfile](https://github.com/yukihiko-shinoda/dockerfile-gatsby/blob/main/Dockerfile)
 
 - **Source of this description**: [docs repo's root directory](https://github.com/yukihiko-shinoda/dockerfile-gatsby)
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,5 @@
-version: "3.6"
 services:
-  sut:
+  gatsby:
     build: .
     command:
       - gatsby


### PR DESCRIPTION
This pull request updates the project to use the `main` branch as the default instead of `master`, modernizes the test workflow, and renames the test service and compose file for clarity and consistency. The most important changes are grouped below:

Branch and documentation updates:

* Changed all references from `master` to `main` in the GitHub Actions workflow configuration and the `README.md` to reflect the updated default branch naming convention. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L5-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13)

Test workflow modernization:

* Updated the GitHub Actions workflow to use `actions/checkout@v6` instead of `v4` and replaced the deprecated `docker-compose` command with the newer `docker compose` syntax. The test service is now run as `gatsby` instead of `sut`.

Compose file and service renaming:

* Renamed the compose file from `docker-compose.test.yml` to `compose.yml` and changed the service name from `sut` to `gatsby` for better clarity and alignment with the project.