### PR TITLE
Upgrade Alpine to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,24 @@
 # see: https://www.stoutlabs.com/blog/2019-02-05-my-docker-setup-gatsby-next/
 # And following official image is legacy
 # see: https://hub.docker.com/r/gatsbyjs/gatsby-dev-builds
-FROM node:21.4.0-alpine3.17
+FROM node:21.4.0-alpine3.18
 
 # - DL3018 is reported when locking apk packageversion by `~` (tilde) · Issue #1165 · hadolint/hadolint
 #   https://github.com/hadolint/hadolint/issues/1165
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
     # gatsby new command depends on git
-    git~2.39.5 \
+    git~2.40.4 \
     # gatsby develop calls lscpu
     util-linux~2.38.1 \
     # gatsby develop --https uses
-    openssl~3.0.15 \
+    openssl~3.1.8 \
     # gatsby develop --https uses
-    sudo~1.9.12_p2 \
+    sudo~1.9.13_p3 \
     # Node-gyp v9.1.0 requires Python3.6.0 or more:
     #   #0 58.43 gyp ERR! find Python - version is 2.7.18 - should be >=3.6.0
     #   #0 58.43 gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
-    python3~3.10.15 \
+    python3~3.11.12 \
     g++~12.2.1_git20220924 \
     # gatsby-plugin-sharp depends on imagemin-mozjpeg,
     # imagemin-mozjpeg depends on mozjpeg,
@@ -37,24 +37,24 @@ RUN apk add --no-cache \
     # - Answer: macos - No acceptable C compiler found in $PATH - Stack Overflow
     #   https://stackoverflow.com/a/57419374/12721873
     gcc~12.2.1_git20220924 \
-    make~4.3 \
-    musl-dev~1.2.3 \
+    make~4.4.1 \
+    musl-dev~1.2.4 \
     # - Package index - Alpine Linux packages
     #   https://pkgs.alpinelinux.org/contents?file=file&path=&name=&branch=v3.15&repo=main&arch=x86
-    file~5.43 \
+    file~5.45 \
     # - Answer: macos - pkg-config: PKG_PROG_PKG_CONFIG: command not found - Stack Overflow
     #   https://stackoverflow.com/a/17106579/12721873
     pkgconfig~1.9.4 \
     # - Build error: no nasm (Netwide Assembler) found · Issue #593 · alicevision/AliceVision
     #   https://github.com/alicevision/AliceVision/issues/593#issuecomment-457194176
-    nasm~2.15.05 \
+    nasm~2.16.01 \
     # sharp depends on vips
     # - Error loading shared library libvips-cpp.so.42: No such file or directory · Issue #773 · lovell/sharp
     #   https://github.com/lovell/sharp/issues/773
-    vips~8.13.3 \
+    vips~8.14.3 \
     # Can't resolve without vips-dev:
     #   #0 64.81 ../src/common.cc:24:10: fatal error: vips/vips8: No such file or directory
-    vips-dev~8.13.3 \
+    vips-dev~8.14.3 \
  && rm -fR /var/cache/apk/*
 
 # Also exposing VSCode debug ports


### PR DESCRIPTION
This pull request updates the development Dockerfile to use newer base images and more recent versions of several key system packages. These updates help ensure compatibility, improve security, and provide access to the latest features and bug fixes.

**Base image and package upgrades:**

* Updated the base image from `node:21.4.0-alpine3.17` to `node:21.4.0-alpine3.18`, providing a more recent Alpine Linux environment.
* Upgraded several critical packages in the `apk add` step, including:
  - `git` from `2.39.5` to `2.40.4`
  - `openssl` from `3.0.15` to `3.1.8`
  - `sudo` from `1.9.12_p2` to `1.9.13_p3`
  - `python3` from `3.10.15` to `3.11.12`
  - `make` from `4.3` to `4.4.1`
  - `musl-dev` from `1.2.3` to `1.2.4`
  - `file` from `5.43` to `5.45`
  - `nasm` from `2.15.05` to `2.16.01`
  - `vips` and `vips-dev` from `8.13.3` to `8.14.3` [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L6-R23) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L40-R57)