### PR TITLE
Upgrade Node to 22.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # see: https://www.stoutlabs.com/blog/2019-02-05-my-docker-setup-gatsby-next/
 # And following official image is legacy
 # see: https://hub.docker.com/r/gatsbyjs/gatsby-dev-builds
-FROM node:21.4.0-alpine3.19
+FROM node:22.12.0-alpine3.19
 
 # - DL3018 is reported when locking apk packageversion by `~` (tilde) · Issue #1165 · hadolint/hadolint
 #   https://github.com/hadolint/hadolint/issues/1165


### PR DESCRIPTION
This pull request updates the base Node.js version used in the `Dockerfile` to ensure the project uses the latest stable environment.

Dependency update:

* Updated the Node.js base image from `node:21.4.0-alpine3.19` to `node:22.12.0-alpine3.19` in the `Dockerfile` to leverage new features, improvements, and security patches.