### PR TITLE
Upgrade gatsby-cli to 5.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ EXPOSE 8000 9000
 # We introduce yarn since it's still faster and isn't found any defintive defects.
 # In Gatsby development, gatsby-cli is required.
 # When install gatsby-cli in global, we can omit it in package.json.
-RUN yarn global add gatsby-cli@4.25.0 && yarn cache clean
+RUN yarn global add gatsby-cli@5.15.0 && yarn cache clean
 
 WORKDIR /workspace
 CMD ["gatsby", "develop", "-H", "0.0.0.0" ]


### PR DESCRIPTION
This pull request updates the global version of `gatsby-cli` installed in the Docker image to ensure compatibility with newer features and bug fixes.

- Dependency update:
  * Upgraded `gatsby-cli` from version 4.25.0 to 5.15.0 in the `Dockerfile` to keep up with the latest Gatsby tooling improvements and security patches.