### PR TITLE
Upgrade Alpine to 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,31 +3,31 @@
 # see: https://www.stoutlabs.com/blog/2019-02-05-my-docker-setup-gatsby-next/
 # And following official image is legacy
 # see: https://hub.docker.com/r/gatsbyjs/gatsby-dev-builds
-FROM node:22.12.0-alpine3.19
+FROM node:22.12.0-alpine3.20
 
 # - DL3018 is reported when locking apk packageversion by `~` (tilde) · Issue #1165 · hadolint/hadolint
 #   https://github.com/hadolint/hadolint/issues/1165
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
     # gatsby new command depends on git
-    git~2.43.7 \
+    git~2.45.4 \
     # gatsby develop calls lscpu
-    util-linux~2.39.3 \
+    util-linux~2.40.1 \
     # gatsby develop --https uses
-    openssl~3.1.8 \
+    openssl~3.3.5 \
     # gatsby develop --https uses
-    sudo~1.9.15_p2 \
+    sudo~1.9.15_p5 \
     # Node-gyp v9.1.0 requires Python3.6.0 or more:
     #   #0 58.43 gyp ERR! find Python - version is 2.7.18 - should be >=3.6.0
     #   #0 58.43 gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
-    python3~3.11.14 \
-    g++~13.2.1_git20231014 \
+    python3~3.12.12 \
+    g++~13.2.1_git20240309 \
     # gatsby-plugin-sharp depends on imagemin-mozjpeg,
     # imagemin-mozjpeg depends on mozjpeg,
     # mozjpeg requires compiling from source with autoreconf, automake, libtool, gcc, make, musl-dev, file, pkgconfig, nasm
     # - Package index - Alpine Linux packages
     #   https://pkgs.alpinelinux.org/contents?page=1&file=autoreconf
-    autoconf~2.71 \
+    autoconf~2.72 \
     # - Error with install: autoreconf fails to run aclocal · Issue #24 · buffer/pylibemu
     #   https://github.com/buffer/pylibemu/issues/24#issuecomment-492759639
     automake~1.16.5 \
@@ -36,9 +36,9 @@ RUN apk add --no-cache \
     libtool~2.4.7 \
     # - Answer: macos - No acceptable C compiler found in $PATH - Stack Overflow
     #   https://stackoverflow.com/a/57419374/12721873
-    gcc~13.2.1_git20231014 \
+    gcc~13.2.1_git20240309 \
     make~4.4.1 \
-    musl-dev~1.2.4 \
+    musl-dev~1.2.5 \
     # - Package index - Alpine Linux packages
     #   https://pkgs.alpinelinux.org/contents?file=file&path=&name=&branch=v3.15&repo=main&arch=x86
     file~5.45 \
@@ -47,14 +47,14 @@ RUN apk add --no-cache \
     pkgconfig~1.9.4 \
     # - Build error: no nasm (Netwide Assembler) found · Issue #593 · alicevision/AliceVision
     #   https://github.com/alicevision/AliceVision/issues/593#issuecomment-457194176
-    nasm~2.16.01 \
+    nasm~2.16.03 \
     # sharp depends on vips
     # - Error loading shared library libvips-cpp.so.42: No such file or directory · Issue #773 · lovell/sharp
     #   https://github.com/lovell/sharp/issues/773
-    vips~8.15.0 \
+    vips~8.15.2 \
     # Can't resolve without vips-dev:
     #   #0 64.81 ../src/common.cc:24:10: fatal error: vips/vips8: No such file or directory
-    vips-dev~8.15.0 \
+    vips-dev~8.15.2 \
  && rm -fR /var/cache/apk/*
 
 # Also exposing VSCode debug ports


### PR DESCRIPTION
This pull request updates the `Dockerfile` to use newer versions of the base image and several key packages. The primary goal is to ensure compatibility with the latest Alpine Linux release and to benefit from recent security and stability improvements in the dependencies.

Dependency and base image updates:

* Updated the base image from `node:22.12.0-alpine3.19` to `node:22.12.0-alpine3.20` for improved security and compatibility.
* Upgraded several important packages in the `apk add` step, including `git`, `util-linux`, `openssl`, `sudo`, `python3`, `g++`, `autoconf`, `gcc`, `musl-dev`, `nasm`, `vips`, and `vips-dev` to their latest available versions in Alpine 3.20. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L6-R30) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L39-R41) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L50-R57)