### PR TITLE
Upgrade Node to 22.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # see: https://www.stoutlabs.com/blog/2019-02-05-my-docker-setup-gatsby-next/
 # And following official image is legacy
 # see: https://hub.docker.com/r/gatsbyjs/gatsby-dev-builds
-FROM node:22.12.0-alpine3.20
+FROM node:22.13.1-alpine3.20
 
 # - DL3018 is reported when locking apk packageversion by `~` (tilde) · Issue #1165 · hadolint/hadolint
 #   https://github.com/hadolint/hadolint/issues/1165


### PR DESCRIPTION
This pull request updates the Node.js version used in the `Dockerfile` to ensure the application runs on the latest patch release, which may include important security and stability improvements.

- **Dependency update:**
  * Updated the base image in `Dockerfile` from `node:22.12.0-alpine3.20` to `node:22.13.1-alpine3.20` to use the latest Node.js patch version.