### PR TITLE
Upgrade Node 22 -> 24, Alpine 3.21 -> 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,58 +3,62 @@
 # see: https://www.stoutlabs.com/blog/2019-02-05-my-docker-setup-gatsby-next/
 # And following official image is legacy
 # see: https://hub.docker.com/r/gatsbyjs/gatsby-dev-builds
-FROM node:22.13.1-alpine3.21
+FROM node:24.19.0-alpine3.24
 
 # - DL3018 is reported when locking apk packageversion by `~` (tilde) · Issue #1165 · hadolint/hadolint
 #   https://github.com/hadolint/hadolint/issues/1165
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
     # gatsby new command depends on git
-    git~2.47.3 \
+    git~2.54.0 \
     # gatsby develop calls lscpu
-    util-linux~2.40.4 \
+    util-linux~2.42.1 \
     # gatsby develop --https uses
-    openssl~3.3.7 \
+    openssl~3.5.7 \
     # gatsby develop --https uses
-    sudo~1.9.17_p1 \
+    sudo~1.9.17_p2 \
     # Node-gyp v9.1.0 requires Python3.6.0 or more:
     #   #0 58.43 gyp ERR! find Python - version is 2.7.18 - should be >=3.6.0
     #   #0 58.43 gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
-    python3~3.12.13 \
-    g++~14.2.0 \
+    python3~3.14.7 \
+    g++~15.2.0 \
     # gatsby-plugin-sharp depends on imagemin-mozjpeg,
     # imagemin-mozjpeg depends on mozjpeg,
     # mozjpeg requires compiling from source with autoreconf, automake, libtool, gcc, make, musl-dev, file, pkgconfig, nasm
     # - Package index - Alpine Linux packages
     #   https://pkgs.alpinelinux.org/contents?page=1&file=autoreconf
-    autoconf~2.72 \
+    autoconf~2.73 \
     # - Error with install: autoreconf fails to run aclocal · Issue #24 · buffer/pylibemu
     #   https://github.com/buffer/pylibemu/issues/24#issuecomment-492759639
-    automake~1.17 \
+    automake~1.18 \
     # - undefined macro: AC_PROG_LIBTOOL · Issue #9 · maxmind/libmaxminddb
     #   https://github.com/maxmind/libmaxminddb/issues/9#issuecomment-30836272
-    libtool~2.4.7 \
+    libtool~2.6.0 \
     # - Answer: macos - No acceptable C compiler found in $PATH - Stack Overflow
     #   https://stackoverflow.com/a/57419374/12721873
-    gcc~14.2.0 \
+    gcc~15.2.0 \
     make~4.4.1 \
-    musl-dev~1.2.5 \
+    musl-dev~1.2.6 \
     # - Package index - Alpine Linux packages
     #   https://pkgs.alpinelinux.org/contents?file=file&path=&name=&branch=v3.15&repo=main&arch=x86
-    file~5.46 \
+    file~5.47 \
     # - Answer: macos - pkg-config: PKG_PROG_PKG_CONFIG: command not found - Stack Overflow
     #   https://stackoverflow.com/a/17106579/12721873
-    pkgconfig~1.9.4 \
+    pkgconf~2.5.1 \
     # - Build error: no nasm (Netwide Assembler) found · Issue #593 · alicevision/AliceVision
     #   https://github.com/alicevision/AliceVision/issues/593#issuecomment-457194176
-    nasm~2.16.03 \
+    nasm~3.01 \
     # sharp depends on vips
     # - Error loading shared library libvips-cpp.so.42: No such file or directory · Issue #773 · lovell/sharp
     #   https://github.com/lovell/sharp/issues/773
-    vips~8.15.3 \
+    vips~8.18.2 \
     # Can't resolve without vips-dev:
     #   #0 64.81 ../src/common.cc:24:10: fatal error: vips/vips8: No such file or directory
-    vips-dev~8.15.3 \
+    vips-dev~8.18.2 \
+    # Python 3.12+ dropped distutils from the stdlib, but node-gyp v9.3.1
+    # (still used by some native modules' install scripts) imports it;
+    # py3-setuptools restores a distutils-compatible shim.
+    py3-setuptools \
  && rm -fR /var/cache/apk/*
 
 # Also exposing VSCode debug ports
@@ -66,7 +70,7 @@ EXPOSE 8000 9000
 # We introduce yarn since it's still faster and isn't found any defintive defects.
 # In Gatsby development, gatsby-cli is required.
 # When install gatsby-cli in global, we can omit it in package.json.
-RUN yarn global add gatsby-cli@5.15.0 && yarn cache clean
+RUN yarn global add gatsby-cli@5.16.0 && yarn cache clean
 
 WORKDIR /workspace
 CMD ["gatsby", "develop", "-H", "0.0.0.0" ]


### PR DESCRIPTION
This pull request updates the `Dockerfile` to use newer versions of the base Node.js image, system packages, and development tools, improving compatibility, security, and build reliability for the Gatsby development environment. It also updates the globally installed `gatsby-cli` version and adds a fix for building native Node modules with Python 3.12+.

**Base image and package updates:**

* Upgraded the base image from `node:22.13.1-alpine3.21` to `node:24.19.0-alpine3.24` for improved Node.js and Alpine Linux support.
* Updated multiple system packages (e.g., `git`, `util-linux`, `openssl`, `python3`, `g++`, `autoconf`, `automake`, `libtool`, `gcc`, `musl-dev`, `file`, `pkgconf`/`pkgconfig`, `nasm`, `vips`, `vips-dev`) to their latest available versions for enhanced security and compatibility.

**Build tool compatibility:**

* Added `py3-setuptools` to restore a `distutils` shim for Python 3.12+, ensuring native Node modules (via `node-gyp`) can still build successfully.

**Gatsby CLI update:**

* Updated the globally installed `gatsby-cli` from version `5.15.0` to `5.16.0`.